### PR TITLE
Configurable Indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Likewise, to remove an instance of tabIndent:
 For styling purposes, after a textarea is enhanced by tabIndent, it will have
 the class `tabIndent-rendered`.
 
+The default tab sequence is '\t', but it can be set to any string you want. For
+example, to use four spaces instead of the tab character, just add the following
+line before rendering:
+
+    tabIndent.config.tab = '    ';
+
 ## Caveat
 
 **tabIndent.js** willingly breaks the default action of the `tab` button, whose

--- a/js/tabIndent.js
+++ b/js/tabIndent.js
@@ -28,7 +28,7 @@ if (!Element.prototype.addEventListener) {
 				}
 				for (var iLstId = 0; iLstId < aElListeners.length; iLstId++) {
 					if (aElListeners[iLstId] === fListener) { return; }
-				}     
+				}
 				aElListeners.push(fListener);
 			}
 		} else {
@@ -52,10 +52,13 @@ if (!Element.prototype.addEventListener) {
 tabIndent = {
 	version: '0.1.6',
 	config: {
+		tab: '\t',
 		images: '../images/'
 	},
 	events: {
 		keydown: function(e) {
+			var tab = tabIndent.config.tab;
+			var tabWidth = tab.length;
 			if (e.keyCode === 9) {
 				e.preventDefault();
 				var	currentStart = this.selectionStart,
@@ -64,9 +67,9 @@ tabIndent = {
 					// Normal Tab Behaviour
 					if (!tabIndent.isMultiLine(this)) {
 						// Add tab before selection, maintain highlighted text selection
-						this.value = this.value.slice(0, currentStart) + "\t" + this.value.slice(currentStart);
-						this.selectionStart = currentStart + 1;
-						this.selectionEnd = currentEnd + 1;
+						this.value = this.value.slice(0, currentStart) + tab + this.value.slice(currentStart);
+						this.selectionStart = currentStart + tabWidth;
+						this.selectionEnd = currentEnd + tabWidth;
 					} else {
 						// Iterating through the startIndices, if the index falls within selectionStart and selectionEnd, indent it there.
 						var	startIndices = tabIndent.findStartIndices(this),
@@ -80,7 +83,7 @@ tabIndent = {
 							if (startIndices[l+1] && currentStart != startIndices[l+1]) lowerBound = startIndices[l+1];
 
 							if (lowerBound >= currentStart && startIndices[l] < currentEnd) {
-								this.value = this.value.slice(0, startIndices[l]) + "\t" + this.value.slice(startIndices[l]);
+								this.value = this.value.slice(0, startIndices[l]) + tab + this.value.slice(startIndices[l]);
 
 								newStart = startIndices[l];
 								if (!newEnd) newEnd = (startIndices[l+1] ? startIndices[l+1] - 1 : 'end');
@@ -89,21 +92,21 @@ tabIndent = {
 						}
 
 						this.selectionStart = newStart;
-						this.selectionEnd = (newEnd !== 'end' ? newEnd + affectedRows : this.value.length);
+						this.selectionEnd = (newEnd !== 'end' ? newEnd + (tabWidth * affectedRows) : this.value.length);
 					}
 				} else {
 					// Shift-Tab Behaviour
 					if (!tabIndent.isMultiLine(this)) {
-						if (this.value.substr(currentStart - 1, 1) == "\t") {
+						if (this.value.substr(currentStart - tabWidth, tabWidth) == tab) {
 							// If there's a tab before the selectionStart, remove it
-							this.value = this.value.substr(0, currentStart - 1) + this.value.substr(currentStart);
-							this.selectionStart = currentStart - 1;
-							this.selectionEnd = currentEnd - 1;
-						} else if (this.value.substr(currentStart - 1, 1) == "\n" && this.value.substr(currentStart, 1) == '\t') {
+							this.value = this.value.substr(0, currentStart - tabWidth) + this.value.substr(currentStart);
+							this.selectionStart = currentStart - tabWidth;
+							this.selectionEnd = currentEnd - tabWidth;
+						} else if (this.value.substr(currentStart - 1, 1) == "\n" && this.value.substr(currentStart, tabWidth) == tab) {
 							// However, if the selection is at the start of the line, and the first character is a tab, remove it
-							this.value = this.value.substring(0, currentStart) + this.value.substr(currentStart + 1);
+							this.value = this.value.substring(0, currentStart) + this.value.substr(currentStart + tabWidth);
 							this.selectionStart = currentStart;
-							this.selectionEnd = currentEnd - 1;
+							this.selectionEnd = currentEnd - tabWidth;
 						}
 					} else {
 						// Iterating through the startIndices, if the index falls within selectionStart and selectionEnd, remove an indent from that row
@@ -118,9 +121,9 @@ tabIndent = {
 							if (startIndices[l+1] && currentStart != startIndices[l+1]) lowerBound = startIndices[l+1];
 
 							if (lowerBound >= currentStart && startIndices[l] < currentEnd) {
-								if (this.value.substr(startIndices[l], 1) == '\t') {
+								if (this.value.substr(startIndices[l], tabWidth) == tab) {
 									// Remove a tab
-									this.value = this.value.slice(0, startIndices[l]) + this.value.slice(startIndices[l] + 1);
+									this.value = this.value.slice(0, startIndices[l]) + this.value.slice(startIndices[l] + tabWidth);
 									affectedRows++;
 								} else {}	// Do nothing
 
@@ -130,7 +133,7 @@ tabIndent = {
 						}
 
 						this.selectionStart = newStart;
-						this.selectionEnd = (newEnd !== 'end' ? newEnd - affectedRows : this.value.length);
+						this.selectionEnd = (newEnd !== 'end' ? newEnd - (affectedRows * tabWidth) : this.value.length);
 					}
 				}
 			} else if (e.keyCode == 27) {

--- a/tests/tabIndent.js
+++ b/tests/tabIndent.js
@@ -4,7 +4,7 @@ Object.defineProperty(tabEvent, 'keyCode', {
     get : function() {
         return this.keyCodeVal;
     }
-});     
+});
 Object.defineProperty(tabEvent, 'which', {
     get : function() {
         return this.keyCodeVal;
@@ -20,7 +20,7 @@ Object.defineProperty(shiftTabEvent, 'keyCode', {
     get : function() {
         return this.keyCodeVal;
     }
-});     
+});
 Object.defineProperty(shiftTabEvent, 'which', {
     get : function() {
         return this.keyCodeVal;
@@ -32,6 +32,7 @@ shiftTabEvent.keyCodeVal = 9;
 
 describe("tabIndent", function() {
 	beforeEach(function() {
+    tabIndent.config.tab = '\t';
 		document.getElementById('env').innerHTML =
 			'<textarea class="tabIndent"></textarea><textarea id="foobar"></textarea><div id="lorem"></div>';
 	});
@@ -135,6 +136,20 @@ describe("tabIndent", function() {
 			expect(el.value).toEqual("\tab\n\tcd");
 			expect(el.selectionStart).toEqual(0);
 			expect(el.selectionEnd).toEqual(7);
+		});
+
+    it('should indent multi-line selection using non-default tab sequence', function() {
+			tabIndent.config.tab = 'abcd';
+			var tabWidth = 4;
+			var el = document.getElementById('foobar');
+			tabIndent.render(el);
+			el.value = "ab\ncd";
+			el.selectionStart = 0;
+			el.selectionEnd = 5;
+			el.dispatchEvent(tabEvent);
+			expect(el.value).toEqual("\tab\n\tcd");
+			expect(el.selectionStart).toEqual(0);
+			expect(el.selectionEnd).toEqual(5 + 2*tabWidth);
 		});
 	});
 


### PR DESCRIPTION
Tabs in Chrome/Firefox are rendering at 8 characters wide, which is much too large for my needs, so I added the ability to set the tab sequence to any string using `tabIndent.config.tab = "anarbitrarytabsequence";`.  It looks like this something you're planning (#2 and #9), so I thought I'd share the code.

I also updated the readme and added some tests. I would've added more but I couldn't get most of the existing tests to work, much less new ones, and I don't have a lot of Jasmine experience.

Very useful project btw.
